### PR TITLE
Set content-type for uploaded files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * Module dependencies
@@ -7,33 +7,33 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable no-unused-vars */
 // Public node modules.
-const _ = require("lodash");
-const fs = require("fs");
-const streamifier = require("streamifier");
-const azurestorage = require("azure-storage");
+const _ = require('lodash');
+const fs = require('fs');
+const streamifier = require('streamifier');
+const azurestorage = require('azure-storage');
 
 module.exports = {
-  provider: "azure",
-  name: "Azure Storage",
+  provider: 'azure',
+  name: 'Azure Storage',
   auth: {
     connectionString: {
-      label: "Connection string",
-      type: "text"
+      label: 'Connection string',
+      type: 'text'
     },
     account: {
-      label: "Account",
-      type: "text"
+      label: 'Account',
+      type: 'text'
     },
     container: {
-      label: "Container",
-      type: "text"
+      label: 'Container',
+      type: 'text'
     }
   },
-  init: config => {
+  init: (config) => {
     const blobService = azurestorage.createBlobService(config.connectionString);
 
     return {
-      upload: file => {
+      upload: (file) => {
         return new Promise((resolve, reject) => {
           const fileStream = streamifier.createReadStream(file.buffer);
           const filename = `${file.hash}${file.ext}`;
@@ -49,17 +49,15 @@ module.exports = {
               if (err) {
                 reject(err);
               }
-            }
+            },
           );
-          fileStream.pipe(writeStream).on("finish", () => {
-            file.url = `https://${config.account}.blob.core.windows.net/${
-              config.container
-            }/${filename}`;
+          fileStream.pipe(writeStream).on('finish', () => {
+            file.url = `https://${config.account}.blob.core.windows.net/${config.container}/${filename}`;
             resolve({ message: `Upload of '${filename}' complete.` });
           });
         });
       },
-      delete: file => {
+      delete: (file) => {
         return new Promise((resolve, reject) => {
           const filename = `${file.hash}${file.ext}`;
           blobService.deleteBlobIfExists(
@@ -70,7 +68,7 @@ module.exports = {
                 reject(err);
               }
               resolve();
-            }
+            },
           );
         });
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 /**
  * Module dependencies
@@ -7,52 +7,59 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable no-unused-vars */
 // Public node modules.
-const _ = require('lodash');
-const fs = require('fs');
-const streamifier = require('streamifier');
-const azurestorage = require('azure-storage');
+const _ = require("lodash");
+const fs = require("fs");
+const streamifier = require("streamifier");
+const azurestorage = require("azure-storage");
 
 module.exports = {
-  provider: 'azure',
-  name: 'Azure Storage',
+  provider: "azure",
+  name: "Azure Storage",
   auth: {
     connectionString: {
-      label: 'Connection string',
-      type: 'text'
+      label: "Connection string",
+      type: "text"
     },
     account: {
-      label: 'Account',
-      type: 'text'
+      label: "Account",
+      type: "text"
     },
     container: {
-      label: 'Container',
-      type: 'text'
+      label: "Container",
+      type: "text"
     }
   },
-  init: (config) => {
+  init: config => {
     const blobService = azurestorage.createBlobService(config.connectionString);
 
     return {
-      upload: (file) => {
+      upload: file => {
         return new Promise((resolve, reject) => {
           const fileStream = streamifier.createReadStream(file.buffer);
           const filename = `${file.hash}${file.ext}`;
           const writeStream = blobService.createWriteStreamToBlockBlob(
             config.container,
             filename,
+            {
+              contentSettings: {
+                contentType: file.mime
+              }
+            },
             (err, res) => {
               if (err) {
                 reject(err);
               }
-            },
+            }
           );
-          fileStream.pipe(writeStream).on('finish', () => {
-            file.url = `https://${config.account}.blob.core.windows.net/${config.container}/${filename}`;
+          fileStream.pipe(writeStream).on("finish", () => {
+            file.url = `https://${config.account}.blob.core.windows.net/${
+              config.container
+            }/${filename}`;
             resolve({ message: `Upload of '${filename}' complete.` });
           });
         });
       },
-      delete: (file) => {
+      delete: file => {
         return new Promise((resolve, reject) => {
           const filename = `${file.hash}${file.ext}`;
           blobService.deleteBlobIfExists(
@@ -63,7 +70,7 @@ module.exports = {
                 reject(err);
               }
               resolve();
-            },
+            }
           );
         });
       }


### PR DESCRIPTION
The default behavior for uploading blobs to Azure is that the content-type will be set to application/octet-stream.

This PR adds support for setting the correct content/mime type in the storage explorer of Azure.